### PR TITLE
Removed ITALICS formatting from dash_grep function (Issue #4)

### DIFF
--- a/dash.c
+++ b/dash.c
@@ -448,7 +448,7 @@ int dash_grep(char **args)
 		}
 	}
 	if(flag == 0)
-		printf(ITALICS "No matches were found" RESET "\n");
+		printf("No matches were found \n");
 	return 1;
 }
 


### PR DESCRIPTION
This fixes the issue #4 titled "Remove ITALICS formatting from dash_grep function".
I have removed ITALICS formatting from dash_grep function in the conditional block where flag == 0.