### PR TITLE
replace vulnerable strcpy

### DIFF
--- a/dash.c
+++ b/dash.c
@@ -234,7 +234,7 @@ int dash_pipe(char **args)
 char *get_hist_file_path()
 {
 	static char file_path[128];
-	strcat(strcpy(file_path, getenv("HOME")), "/.dash_history");
+	strcat(strncpy(file_path, getenv("HOME"), 113), "/.dash_history");
 	return file_path;
 }
 


### PR DESCRIPTION
I found two `strcpy`s in `dash.c`. The second one seems safe because the source string is made with `fgets`.

The first `strcpy`, however, appears vulnerable to a buffer overflow from an environment variable. I changed it to `strncpy`.